### PR TITLE
Add uninstallation steps for root certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ remedy this, there is a a few tricks built into windows. So here goes:
 4.  ```pnputil /delete-driver oem139.inf```
 5.  (If you still get multiple displays after uninstall, try to repeat uninstall procedure in safemode.)
 
-
-
-## Removing Certificates (Optional)
+### Removing Certificates (Optional)
 
 To uninstall the root certificate:
 
@@ -80,7 +78,6 @@ To uninstall the root certificate:
 5. In the sidebar, expand `Trusted Publishers` -> `Certificates` folder.
 6. Scroll to the bottom, until you see "Virtual Display Driver". 
 7. Right click "Virtual Display Driver" and hit "Delete". In the warning that appears, choose "Yes".
-
 
 
 ## HDR Support Now Available for Windows 11 22H2+ 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ This project uses the official Windows Indirect Display Driver combined with the
 3. Right click on IddSampleDriver, choose "Uninstall device"
 4. There is a new popup window, in there click Attempt to remove driver for this device.
 
+To uninstall the root certificate:
+
+1. Search for "Manage user certificates" from the Start menu and open the app.
+2. In the sidebar, open the `Certificates - Current User` -> `Trusted Root Certification Authorities` -> `Certificates` folder.
+3. Scroll to the bottom of the list on the right hand side pane, you should see "Virtual Display Driver".
+4. Right click "Virtual Display Driver" and hit "Delete".
+5. In the warning that appears, choose "Yes".
+6. The root certificate has now been deleted and you can close the "Manage user certificates" window.
+
 ## Manual/Forced Uninstall
 
 Next instructions are for those cases where the device is removed from the system, but driver stil remains. This happens when there is a connection to the device while trying to remove the drivers. To

--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ This project uses the official Windows Indirect Display Driver combined with the
 3. Right click on IddSampleDriver, choose "Uninstall device"
 4. There is a new popup window, in there click Attempt to remove driver for this device.
 
-To uninstall the root certificate:
-
-1. Search for "Manage user certificates" from the Start menu and open the app.
-2. In the sidebar, open the `Certificates - Current User` -> `Trusted Root Certification Authorities` -> `Certificates` folder.
-3. Scroll to the bottom of the list on the right hand side pane, you should see "Virtual Display Driver".
-4. Right click "Virtual Display Driver" and hit "Delete".
-5. In the warning that appears, choose "Yes".
-6. The root certificate has now been deleted and you can close the "Manage user certificates" window.
 
 ## Manual/Forced Uninstall
 
@@ -74,6 +66,22 @@ remedy this, there is a a few tricks built into windows. So here goes:
 3. Locate iddsampledriver.inf, there might be multiple pages of text. Make a note of the "published name", it's often unique for your system, but might look like "oem139.inf"
 4.  ```pnputil /delete-driver oem139.inf```
 5.  (If you still get multiple displays after uninstall, try to repeat uninstall procedure in safemode.)
+
+
+
+## Removing Certificates (Optional)
+
+To uninstall the root certificate:
+
+1. Search for "Manage computer certificates" from the Start menu and open the app.
+2. In the sidebar, expand `Trusted Root Certification Authorities` -> `Certificates` folder.
+3. Scroll to the bottom, until you see "Virtual Display Driver".
+4. Right click "Virtual Display Driver" and hit "Delete". In the warning that appears, choose "Yes".
+5. In the sidebar, expand `Trusted Publishers` -> `Certificates` folder.
+6. Scroll to the bottom, until you see "Virtual Display Driver". 
+7. Right click "Virtual Display Driver" and hit "Delete". In the warning that appears, choose "Yes".
+
+
 
 ## HDR Support Now Available for Windows 11 22H2+ 
 


### PR DESCRIPTION
I couldn't get HDR working in the end, so I decided to uninstall VDD and I noticed there was no undo step for the batch script.

Tbh, we could probably write a script for this!

(If you're wondering why: apparently Moonlight says my AMD RX 5700XT GPU is incompatible with HDR streaming? Seems false according to Google but I'm giving up on this for now.)