### PR TITLE
Add Note About Microsoft Visual C++ Redistributable Requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Unlike physical monitors, this virtual display can support resolutions and refre
 
 Note, Before using the Virtual Display Driver, ensure the following dependencies are installed:
 - **Microsoft Visual C++ Redistributable**  
-  If you encounter the error `vcruntime140.dll not found`, download and install the latest version from the [Microsoft Visual C++ Redistributable page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported).
+  If you encounter the error `vcruntime140.dll not found`, download and install the latest version from the [Microsoft Visual C++ Redistributable page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
 ## EDID Database
 - [EDID Database by Bud3699](https://edid.mikethetech.com/)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Unlike physical monitors, this virtual display can support resolutions and refre
 
 - [Driver Installer (Windows 10/11)](https://github.com/VirtualDisplay/Virtual-Display-Driver/releases) - Check release page for release notes.
 
-Note, Before using the Virtual Display Driver, ensure the following dependencies are installed:
-- **Microsoft Visual C++ Redistributable**  
-  If you encounter the error `vcruntime140.dll not found`, download and install the latest version from the [Microsoft Visual C++ Redistributable page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
+> [!IMPORTANT]
+> Before using the Virtual Display Driver, ensure the following dependencies are installed:
+> - **Microsoft Visual C++ Redistributable**  
+>   If you encounter the error `vcruntime140.dll not found`, download and install the latest version from the [Microsoft Visual C++ Redistributable page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
 ## EDID Database
 - [EDID Database by Bud3699](https://edid.mikethetech.com/)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,17 @@ Unlike physical monitors, this virtual display can support resolutions and refre
 
 - [Driver Installer (Windows 10/11)](https://github.com/VirtualDisplay/Virtual-Display-Driver/releases) - Check release page for release notes.
 
+Note, Before using the Virtual Display Driver, ensure the following dependencies are installed:
+- **Microsoft Visual C++ Redistributable**  
+  If you encounter the error `vcruntime140.dll not found`, download and install the latest version from the [Microsoft Visual C++ Redistributable page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported).
+
 ## EDID Database
 - [EDID Database by Bud3699](https://edid.mikethetech.com/)
 
   You can use this database to load custom edid's into the driver! Or just general edid usage :) 
+
+
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Note, Before using the Virtual Display Driver, ensure the following dependencies
 
   You can use this database to load custom edid's into the driver! Or just general edid usage :) 
 
-
-
-
 ## Installation
 
 - Step 1: Download the Installer


### PR DESCRIPTION
This PR adds a note in the README.md about the requirement for the Microsoft Visual C++ Redistributable. Without it, the VDD Companion fails to open, returning a vcruntime140.dll not found error (along with other related errors). I encountered this issue during my first installation attempt on a VM.