### PR TITLE
Module_install.bat and get_disp_num.p1 (DISPLAY#)

### DIFF
--- a/Community Scripts/get_disp_num.ps1
+++ b/Community Scripts/get_disp_num.ps1
@@ -1,0 +1,1 @@
+Get-Monitor | Where-Object { $_.InstanceName -like '*MTT1337*' } | Sort-Object { [int] (($_.InstanceName -match 'UID(\d+)') -and $Matches[1]) } | Select-Object -First 1 -ExpandProperty LogicalDisplay | select-object Devicename

--- a/Community Scripts/modules_install.bat
+++ b/Community Scripts/modules_install.bat
@@ -1,0 +1,20 @@
+@echo off
+
+:: Use PowerShell for elevation check and execution
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator');" ^
+    "if (-not $elevated) {" ^
+        "$CommandLine = '-File \"' + $MyInvocation.MyCommand.Path + '\" ' + $MyInvocation.UnboundArguments;" ^
+        "Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine;" ^
+        "Exit" ^
+    "} else {" ^
+        "Install-Module -Name DisplayConfig -Scope AllUsers -Force -AllowClobber;" ^
+        "Install-Module -Name MonitorConfig -Scope AllUsers -Force -AllowClobber;" ^
+        "if ($?) {" ^
+            "Write-Output 'Modules installed successfully.'" ^
+        "} else {" ^
+            "Write-Output 'An error occurred while installing the modules.'" ^
+        "}" ^
+    "}"
+
+pause


### PR DESCRIPTION
Since dep_fix.ps1 seem less then reliable, I've created a bat file that installs the needed powershell modules. It needs admin privs. to install to all users on the machine. I'm planning on running this .bat during the installer in case the user choose to install the scripts.

The get_disp_num.ps1 is for those users depending on \\\\.\\DISPLAY number to get the right display for their scripting needs in their "automation"